### PR TITLE
Add real CRUD integration test using H2

### DIFF
--- a/dfss-test-application/pom.xml
+++ b/dfss-test-application/pom.xml
@@ -32,6 +32,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Embedded database for tests -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- 5. 构建插件：Spring Boot 插件 直接继承父 POM pluginManagement，不用再写版本 -->

--- a/dfss-test-application/src/test/java/com/dfss/application/DataBaseOperationTest.java
+++ b/dfss-test-application/src/test/java/com/dfss/application/DataBaseOperationTest.java
@@ -2,14 +2,13 @@
 package com.dfss.application;
 
 
-import com.alibaba.fastjson.JSON;
-import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
 import com.dfss.data.util.DataBaseOperation;
 import com.dfss.application.entity.Product;
 import com.dfss.application.entity.User;
 import com.dfss.application.vo.UserVO;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,35 +25,40 @@ class DataBaseOperationTest {
 
     @Test
     void save_list_getOne_update_delete_works() {
-//        // 2. 插入几条
-//        User u1 = new User();
-//        u1.setName("Tom");
-//        u1.setEmail("tom@example.com");
-//        DataBaseOperation.insert(u1);
-//
-//
-//        // 2. 插入几条
-//        Product p1 = new Product();
-//        p1.setName("Tom");
-//        p1.setDescription("tom@example.com");
-//        DataBaseOperation.insert(p1);
-//
-//
-//        User query1 = new User();
-//        query1.setName("Tom");
-//
-//        IPage<UserVO> voPage = DataBaseOperation.page(query1, UserVO.class, 1, 10);
-//        log.info("{}", JSON.toJSONString(voPage));
-//        List<UserVO> vos = voPage.getRecords();
-//        log.info("{}", JSON.toJSONString(vos));
+        // insert user
+        User user = new User();
+        user.setName("Tom");
+        user.setEmail("tom@example.com");
+        int userInsert = DataBaseOperation.insert(user);
+        Assertions.assertThat(userInsert).isEqualTo(1);
+        Assertions.assertThat(user.getId()).isNotNull();
 
+        // insert product
+        Product product = new Product();
+        product.setName("Book");
+        product.setDescription("A book");
+        int productInsert = DataBaseOperation.insert(product);
+        Assertions.assertThat(productInsert).isEqualTo(1);
+        Assertions.assertThat(product.getId()).isNotNull();
 
-        List<User> users = DataBaseOperation.listByWrapper(
-                User.class,
-                DataBaseOperation.lambdaQuery(User.class)
-                        .isNotNull(User::getEmail)
-        );
+        // query page
+        User query = new User();
+        query.setName("Tom");
+        IPage<UserVO> page = DataBaseOperation.page(query, UserVO.class, 1, 10);
+        Assertions.assertThat(page.getTotal()).isEqualTo(1);
+        Assertions.assertThat(page.getRecords()).hasSize(1);
+        Assertions.assertThat(page.getRecords().get(0).getEmail()).isEqualTo("tom@example.com");
 
-        log.info("{}", JSON.toJSONString(users));
+        // update
+        user.setEmail("new@example.com");
+        DataBaseOperation.updateById(user);
+        User afterUpdate = DataBaseOperation.getById(User.class, user.getId());
+        Assertions.assertThat(afterUpdate.getEmail()).isEqualTo("new@example.com");
+
+        // delete
+        DataBaseOperation.deleteById(User.class, user.getId());
+        DataBaseOperation.deleteById(Product.class, product.getId());
+        Assertions.assertThat(DataBaseOperation.getById(User.class, user.getId())).isNull();
+        Assertions.assertThat(DataBaseOperation.getById(Product.class, product.getId())).isNull();
     }
 }

--- a/dfss-test-application/src/test/resources/application.yml
+++ b/dfss-test-application/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=MYSQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  sql:
+    init:
+      schema-locations: classpath:schema.sql
+      mode: always
+mybatis-plus:
+  configuration:
+    log-impl: org.apache.ibatis.logging.stdout.StdOutImpl

--- a/dfss-test-application/src/test/resources/schema.sql
+++ b/dfss-test-application/src/test/resources/schema.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user (
+  id BIGINT PRIMARY KEY,
+  name VARCHAR(255),
+  email VARCHAR(255)
+);
+
+CREATE TABLE product (
+  id BIGINT PRIMARY KEY,
+  name VARCHAR(255),
+  description VARCHAR(255)
+);


### PR DESCRIPTION
## Summary
- enable in-memory DB for tests
- verify CRUD operations with DataBaseOperation

## Testing
- `mvn test -pl dfss-test-application` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3028070832585bc70737697bbad