### PR TITLE
Fix Chinese comment

### DIFF
--- a/dfss-spring-boot/src/main/java/com/dfss/springboot/web/WebMvcConfig.java
+++ b/dfss-spring-boot/src/main/java/com/dfss/springboot/web/WebMvcConfig.java
@@ -22,6 +22,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry
                 .addInterceptor(apiLoggingInterceptor)
                 .addPathPatterns("/**")     // 拦截所有路径
-                .excludePathPatterns("/error"); // 排除 Spring Boot 默认的 /error 断点
+                .excludePathPatterns("/error"); // 排除 Spring Boot 默认的 /error 端点
     }
 }


### PR DESCRIPTION
## Summary
- fix typo in WebMvcConfig comment

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa3019d408325831008276c55f9c6